### PR TITLE
Replace bazel with our own package watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,4 +94,24 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
-RUN yarn global add @bazel/ibazel
+###################
+# Install watchman
+###################
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    autoconf \
+    automake \
+    build-essential \
+    python-dev \
+    libtool \
+    libssl-dev \
+    pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/facebook/watchman.git /tmp/watchman \
+  && cd /tmp/watchman \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && make install \
+  && cd / \
+  && rm -rf /tmp/watchman

--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@
 
 ### TODO
 
-* Work around [issue](https://github.com/bazelbuild/bazel-watcher/issues/135) where ibazel doens't recognize added files
-* Work around issue where ibazel terminates if the build fails
+* Get bazel zipper working

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,6 @@ services:
             - bazel_repository_cache:/root/.cache/bazel_repository_cache/
             - yarn_cache:/usr/local/share/.cache/yarn/
         working_dir: /src
-        command: ["/usr/local/bin/ibazel", "run", "//my-es6-lib:build"]
+        # command: ["/usr/local/bin/ibazel", "run", "//my-es6-lib:build"]
         # command: ["/bin/bash", "-c", "echo \"sleeping indefinitely\"; while true; do sleep 100; done"]
+        command: ["/bin/bash", "-c", "(cd /src/internal/bazel-watch && npm i && node bazel-watch.js -R /src -i 'my-es6-lib/**/*' -e 'my-es6-lib/dist/**/*' /usr/bin/bazel run //my-es6-lib:build)"]

--- a/packages/internal/bazel-watch/bazel-watch.js
+++ b/packages/internal/bazel-watch/bazel-watch.js
@@ -1,0 +1,101 @@
+'use strict'
+
+const ChildProcess = require('./child-process')
+const log = require('./log')
+const Path = require('path')
+const pkg = require('./package.json')
+const program = require('commander')
+const sane = require('sane')
+
+const addToArray = (val, memo) => {
+    if (!memo) {
+        memo = []
+    }
+    memo.push(val)
+    return memo
+}
+
+const main = async () => {
+    let op = 'parsing arguments'
+    try {
+        program
+            .version(pkg.version)
+            .usage('[options] <bazelCommand> <bazelArgs>')
+            .option('-i, --include <glob>', 'include a glob to watch', addToArray)
+            .option('-e, --exclude <glob>', 'exclude a glob from watch', addToArray)
+            .option('-r, --relative-env <env_var>', 'include/exclude are relative to this env var [BUILD_WORKSPACE_DIRECTORY]')
+            .option('-R, --relative <dir>', 'include/exclude are relative to this path')
+            .option('-p, --poll', 'use polling mode')
+            .option('-n, --node-watch', 'use native node file watching')
+            .option('-w, --watchexec', 'use \'watchexec\' for file watching')
+            .option('-d, --dot', 'watch dot files')
+            .option('-W, --watchman-path', 'specify path to watchman')
+            .parse(process.argv)
+
+        let {relative: relativeDir} = program
+
+        const {
+            include: glob,
+            exclude: ignored,
+            poll,
+            nodeWatch,
+            watchexec,
+            dot,
+            watchmanPath,
+        } = program
+
+        if (!relativeDir) {
+            relativeDir = process.env[program.relativeEnv || 'BUILD_WORKSPACE_DIRECTORY']
+        }
+
+        const saneOptions = {
+            glob,
+            ignored,
+            dot,
+        }
+
+        if (poll) {
+            saneOptions.poll = true
+        } else if (watchexec) {
+            saneOptions.watchexec = true
+        } else if (!nodeWatch) {
+            saneOptions.watchman = true
+            saneOptions.watchmanPath = watchmanPath
+        }
+
+        const args = [...program.args]
+        const command = args.shift()
+
+        const childProcess = new ChildProcess({
+            command,
+            args,
+            cwd: relativeDir,
+        })
+
+        const watcher = sane(relativeDir, saneOptions)
+        watcher.on('ready', () => {
+            childProcess.activate()
+        })
+        watcher.on('change', (filepath, root, stat) => {
+            childProcess.restart()
+        })
+        watcher.on('add', (filepath, root, stat) => {
+            childProcess.restart()
+        })
+        watcher.on('delete', (filepath, root) => {
+            childProcess.restart()
+        })
+
+    } catch (e) {
+        console.error('Problem', op, e.stack)
+    }
+}
+
+main()
+    .then(() => {
+        console.log('watch started')
+        // process.exit(0)
+    })
+    .catch(e => {
+        process.exit(-1)
+    })

--- a/packages/internal/bazel-watch/child-process.js
+++ b/packages/internal/bazel-watch/child-process.js
@@ -1,0 +1,183 @@
+'use strict'
+
+const FSM = require('./fsm')
+const killPID = require('./kill-pid-tree')
+const log = require('./log')
+const {spawn} = require('child_process')
+
+const toObject = (accum, x) => {
+    accum[x] = x
+    return accum
+}
+
+const states = [
+    'inactive',       // our initial state
+    'active',
+    'waitToRestart',  // Wait a bit and then spawn the child
+    'error',
+].reduce(toObject, {})
+
+const inputs = [
+    'activate',
+    'deactivate',
+    'restart',
+].reduce(toObject, {})
+
+const _childProcess = new WeakMap()
+const _restartWait = new WeakMap()
+
+class ChildProcess extends FSM {
+    constructor({
+        command,
+        args = [],
+        stdio = 'inherit',
+        env = process.env,
+        cwd = process.cwd(),
+        restartWait = 0,
+    }) {
+        super({
+            logPrefix: '[ChildProcess-FSM] ',
+            states,
+            initialState: states.inactive,
+            inputs,
+            config: {
+                [states.inactive]: {
+                    [inputs.activate]: () => {
+                        this.transition(states.active)
+                    },
+
+                    [inputs.restart]: () => {
+                        this.transition(states.active)
+                    },
+
+                    [inputs.deactivate]: () => {
+                        // noop
+                    },
+                },
+
+                [states.active]: {
+                    onEnter: () => {
+                        const transitionCount = this.transitionCount
+
+                        if (_childProcess.get(this)) {
+                            throw new Error('childProcess must not exist')
+                        }
+
+                        log.debug(`${this.logPrefix}Spawning child process`)
+                        _childProcess.set(this, spawn(
+                            command,
+                            args,
+                            {
+                                cwd,
+                                detached: true,
+                                stdio,
+                                env
+                            },
+                            (e) => {
+                                if (this.transitionCount !== transitionCount) {
+                                    log.debug(`${this.logPrefix}Ignoring child process exit due to transition`)
+                                    return
+                                }
+
+                                if (e) {
+                                    log.error(`${this.logPrefix}Child process exited with error`, e.stack)
+                                } else {
+                                    log.debug(`${this.logPrefix}Child process exited normally`)
+                                }
+
+                                _childProcess.delete(this)
+
+                                // If the child exited and we've never left this state
+                                // it's cause the child terminated on its own. Wait a
+                                // few and respawn it.
+                                this.transition(states.waitToRestart)
+                            }
+                        ))
+                    },
+
+                    [inputs.activate]: () => {
+                        // noop
+                    },
+
+                    [inputs.restart]: () => {
+                        this.transition(states.waitToRestart)
+                    },
+
+                    [inputs.deactivate]: () => {
+                        this.transition(states.inactive)
+                    },
+
+                    onExit: () => {
+                        const childProcess = _childProcess.get(this)
+
+                        // If child doesn't exist, its cause we're transitioning to
+                        // waitToRestart
+                        if (childProcess) {
+                            const {pid} = childProcess
+                            _childProcess.delete(this)
+
+                            log.debug(`${this.logPrefix}Killing child process(${pid})`)
+                            try {
+                                killPID(pid, 'SIGKILL')
+                            } catch (e) {
+                                log.error(`${this.logPrefix}Problem killing child process:`, e.stack)
+                                throw e
+                            }
+
+                        }
+                    },
+                },
+
+                [states.waitToRestart]: {
+                    onEnter: () => {
+                        const transitionCount = this.transitionCount
+                        const restartWait = _restartWait.get(this)
+
+                        log.debug(`${this.logPrefix}Waiting ${restartWait} seconds before respawning child process`)
+                        setTimeout(() => {
+                            if (this.transitionCount !== transitionCount) {
+                                log.debug(`${this.logPrefix}Aborting child process respawn due to transition`)
+                                return
+                            }
+
+                            this.transition(states.active)
+                        }, restartWait * 1000)
+                    },
+
+                    [inputs.activate]: () => {
+                        // noop
+                    },
+
+                    [inputs.restart]: () => {
+                        // noop
+                    },
+
+                    [inputs.deactivate]: () => {
+                        this.transition(states.inactive)
+                    },
+                },
+
+                [states.error]: {
+                    onEnter: () => {
+                        log.error(`${this.logPrefix}Child process fsm error detected.`)
+                    },
+                },
+            }
+        })
+        _restartWait.set(this, restartWait)
+    }
+
+    activate() {
+        this.enqueue(inputs.activate)
+    }
+
+    deactivate() {
+        this.enqueue(inputs.deactivate)
+    }
+
+    restart() {
+        this.enqueue(inputs.restart)
+    }
+}
+
+module.exports = ChildProcess

--- a/packages/internal/bazel-watch/fsm.js
+++ b/packages/internal/bazel-watch/fsm.js
@@ -1,0 +1,138 @@
+/**
+ * A light-weight version of machina.js
+ **/
+'use strict'
+
+const assert = require('assert')
+const EventEmitter = require('events')
+const log = require('./log')
+
+const _config = new WeakMap()
+const _inputQueue = new WeakMap()
+const _inputs = new WeakMap()
+const _pumping = new WeakMap()
+const _state = new WeakMap()
+const _states = new WeakMap()
+const _transitionCount = new WeakMap()
+const _logPrefix = new WeakMap()
+
+class FSM extends EventEmitter {
+    constructor({states, initialState, inputs, config, logPrefix = 'FSM'}) {
+        super()
+        _logPrefix.set(this, logPrefix)
+        _config.set(this, config)
+        _inputQueue.set(this, [])
+        _inputs.set(this, inputs)
+        _pumping.set(this, false)
+        _state.set(this, initialState)
+        _states.set(this, states)
+        _transitionCount.set(this, 0)
+    }
+
+    get logPrefix() {
+        return _logPrefix.get(this)
+    }
+
+    get state() {
+        return _state.get(this)
+    }
+
+    enqueue(input) {
+        const inputs = _inputs.get(this)
+        if (!inputs[input]) {
+            throw new Error(`Invalid input(${input})`)
+        }
+
+       // this.emit('log', `[FSM] Received input(${input})`)
+       _inputQueue.get(this).push(input)
+       pump.call(this)
+    }
+
+    /**
+     * Protected getter to retrieve the _transitionCount
+     */
+    get transitionCount() {
+        return _transitionCount.get(this)
+    }
+
+    /**
+     * Protected method to transition to a new state
+     */
+    transition(newState) {
+        let state = _state.get(this)
+        if (state === newState) {
+            return
+        }
+
+        const states = _states.get(this)
+        const config = _config.get(this)
+        const logPrefix = _logPrefix.get(this)
+
+        if (!states[newState]) {
+            throw new Error(`Invalid state(${newState})`)
+        }
+
+        // Fire the previous state's onExit handler if it exists
+        const onExit = config[state].onExit
+        if (onExit) {
+            try {
+                onExit()
+            } catch (e) {
+                log.error(`${logPrefix}Error in ${state}.onExit handler`, e.stack)
+            }
+        }
+
+        // Transition
+        log.debug(`${logPrefix}transitioning from ${state} to ${newState}`)
+        state = newState
+        _state.set(this, state)
+
+        let transitionCount = _transitionCount.get(this)
+        if (transitionCount++ >= 1e8) {
+            this._transitionCount = 0
+        }
+        _transitionCount.set(this, transitionCount)
+
+        // Fire the new state's onExit handler if it exists
+        assert(config[state], `config[${state}] must exist`)
+        const onEnter = config[state].onEnter
+        if (onEnter) {
+            try {
+                onEnter()
+            } catch (e) {
+                log.error(`${logPrefix}Error in ${state}.onEnter handler`, e.stack)
+            }
+        }
+
+        // Pump messages
+        pump.call(this)
+    }
+}
+
+function pump() {
+    if (!_pumping.get(this)) {
+        _pumping.set(this, true)
+        try {
+            const inputQueue = _inputQueue.get(this)
+            const logPrefix = _logPrefix.get(this)
+
+            while (inputQueue.length > 0) {
+                const input = inputQueue.shift()
+                const state = this.state
+                const handler = _config.get(this)[state][input]
+                if (!handler) {
+                    throw new Error(`Input(${input}) is not valid when in state(${state})`)
+                }
+                try {
+                    handler()
+                } catch (e) {
+                    log.error(`${logPrefix}Error in states[${state}][${input}] handler`, e.stack)
+                }
+            }
+        } finally {
+            _pumping.set(this, false)
+        }
+    }
+}
+
+module.exports = FSM

--- a/packages/internal/bazel-watch/kill-pid-tree.js
+++ b/packages/internal/bazel-watch/kill-pid-tree.js
@@ -1,0 +1,141 @@
+'use strict'
+
+var childProcess = require('child_process')
+var spawn = childProcess.spawn
+var exec = childProcess.exec
+
+// taken from https://github.com/pkrumins/node-tree-kill/blob/6d6843c68aa0353813f259103ca1ead72d1a3d20/index.js
+// and prettified
+module.exports = function(pid, signal, callback) {
+    var tree = {}
+    var pidsToProcess = {}
+    tree[pid] = []
+    pidsToProcess[pid] = 1
+
+    if (typeof signal === 'function' && callback === undefined) {
+        callback = signal
+        signal = undefined
+    }
+
+    switch (process.platform) {
+        case 'win32':
+            exec('taskkill /pid ' + pid + ' /T /F', callback)
+            break
+        case 'darwin':
+            buildProcessTree(
+                pid,
+                tree,
+                pidsToProcess,
+                function(parentPid) {
+                    return spawn('pgrep', ['-P', parentPid])
+                },
+                function() {
+                    killAll(tree, signal, callback)
+                },
+            )
+            break
+        // case 'sunos':
+        //     buildProcessTreeSunOS(pid, tree, pidsToProcess, function () {
+        //         killAll(tree, signal, callback);
+        //     });
+        //     break;
+        default:
+            // Linux
+            buildProcessTree(
+                pid,
+                tree,
+                pidsToProcess,
+                function(parentPid) {
+                    return spawn('ps', [
+                        '-o',
+                        'pid',
+                        '--no-headers',
+                        '--ppid',
+                        parentPid,
+                    ])
+                },
+                function() {
+                    killAll(tree, signal, callback)
+                },
+            )
+            break
+    }
+}
+
+function killAll(tree, signal, callback) {
+    var killed = {}
+    try {
+        Object.keys(tree).forEach(function(pid) {
+            tree[pid].forEach(function(pidpid) {
+                if (!killed[pidpid]) {
+                    killPid(pidpid, signal)
+                    killed[pidpid] = 1
+                }
+            })
+            if (!killed[pid]) {
+                killPid(pid, signal)
+                killed[pid] = 1
+            }
+        })
+    } catch (err) {
+        if (callback) {
+            return callback(err)
+        } else {
+            throw err
+        }
+    }
+    if (callback) {
+        return callback()
+    }
+}
+
+function killPid(pid, signal) {
+    try {
+        process.kill(parseInt(pid, 10), signal)
+    } catch (err) {
+        if (err.code !== 'ESRCH') throw err
+    }
+}
+
+function buildProcessTree(
+    parentPid,
+    tree,
+    pidsToProcess,
+    spawnChildProcessesList,
+    cb,
+) {
+    var ps = spawnChildProcessesList(parentPid)
+    var allData = ''
+    ps.stdout.on('data', function(data) {
+        var data = data.toString('ascii')
+        allData += data
+    })
+
+    var onClose = function(code) {
+        delete pidsToProcess[parentPid]
+
+        if (code != 0) {
+            // no more parent processes
+            if (Object.keys(pidsToProcess).length == 0) {
+                cb()
+            }
+            return
+        }
+
+        allData.match(/\d+/g).forEach(function(pid) {
+            pid = parseInt(pid, 10)
+            tree[parentPid].push(pid)
+            tree[pid] = []
+            pidsToProcess[pid] = 1
+            buildProcessTree(
+                pid,
+                tree,
+                pidsToProcess,
+                spawnChildProcessesList,
+                cb,
+            )
+        })
+    }
+
+    ps.on('close', onClose)
+}

--- a/packages/internal/bazel-watch/log.js
+++ b/packages/internal/bazel-watch/log.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const TRACE = 0
+const DEBUG = 1
+const INFO = 2
+const WARN = 3
+const ERROR = 4
+const FATAL = 5
+
+const LOG_LEVEL = (() => {
+    switch (process.env.LOG_LEVEL) {
+        case 'trace':
+            return TRACE
+        case 'debug':
+            return DEBUG
+        case 'info':
+            return INFO
+        case 'warn':
+            return WARN
+        case 'error':
+            return ERROR
+        case 'fatal':
+            return FATAL
+        default:
+            const intLevel = parseInt(process.env.LOG_LEVEL)
+            return isNaN(intLevel) ? ERROR : intLevel
+    }
+})()
+
+const log = (logLevel, ...rest) => {
+    if (logLevel >= LOG_LEVEL) {
+        if (logLevel >= ERROR) {
+            console.error(...rest)
+        } else if (logLevel >= WARN) {
+            console.warn(...rest)
+        } else {
+            console.log(...rest)
+        }
+    }
+}
+
+module.exports = {
+    trace: log.bind(null, TRACE),
+    debug: log.bind(null, DEBUG),
+    info: log.bind(null, INFO),
+    warn: log.bind(null, WARN),
+    error: log.bind(null, ERROR),
+    fatal: log.bind(null, ERROR),
+}

--- a/packages/internal/bazel-watch/package-lock.json
+++ b/packages/internal/bazel-watch/package-lock.json
@@ -1,0 +1,1222 @@
+{
+    "name": "@pward123/bazel-watch",
+    "version": "0.1.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "requires": {
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "requires": {
+                "node-int64": "0.4.0"
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            }
+        },
+        "capture-exit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "requires": {
+                "rsvp": "3.6.2"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
+        },
+        "commander": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "requires": {
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.6.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
+            }
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "exec-sh": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+            "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg=="
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "requires": {
+                "cross-spawn": "6.0.5",
+                "get-stream": "4.1.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "requires": {
+                "bser": "2.0.0"
+            }
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "requires": {
+                "pump": "3.0.0"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "requires": {
+                "tmpl": "1.0.4"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "requires": {
+                "object-visit": "1.0.1"
+            }
+        },
+        "merge": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "requires": {
+                "path-key": "2.0.1"
+            }
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
+        "sane": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.0.2.tgz",
+            "integrity": "sha512-/3STCUfNSgMVpoREJc1i6ajKFlYZ5OflzZTOhlqPLa+01Ey+QR9iGZK7K5/qIRsQbEDCvqEJH/PL7yZywmnWsA==",
+            "requires": {
+                "anymatch": "2.0.0",
+                "capture-exit": "1.2.0",
+                "exec-sh": "0.3.2",
+                "execa": "1.0.0",
+                "fb-watchman": "2.0.0",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7",
+                "watch": "0.18.0"
+            }
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "requires": {
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                }
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "requires": {
+                "makeerror": "1.0.11"
+            }
+        },
+        "watch": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "requires": {
+                "exec-sh": "0.2.2",
+                "minimist": "1.2.0"
+            },
+            "dependencies": {
+                "exec-sh": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+                    "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+                    "requires": {
+                        "merge": "1.2.1"
+                    }
+                }
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+    }
+}

--- a/packages/internal/bazel-watch/package.json
+++ b/packages/internal/bazel-watch/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@pward123/bazel-watch",
+    "description": "",
+    "version": "0.1.0",
+    "bin": {
+        "babel": "dist/bazel-watch.js"
+    },
+    "main": "dist/bazel-watch.js",
+    "dependencies": {
+        "commander": "^2.19.0",
+        "fb-watchman": "^2.0.0",
+        "sane": "^4.0.2"
+    }
+}

--- a/packages/internal/rsync-dir/rsync-dir.js
+++ b/packages/internal/rsync-dir/rsync-dir.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const fsextra = require('fs-extra')
 const pkg = require('./package.json')
 const Path = require('path')
-const program = require("commander");
+const program = require('commander')
 const {promisify} = require('util')
 const childProcess = require('child_process')
 
@@ -37,7 +37,7 @@ const main = async () => {
             .option('-d, --dest-relative <env_var>', 'destPath is relative to this env var [BUILD_WORKSPACE_DIRECTORY]')
             .option('-n, --no-delete', 'Retain files in destPath that don\'t exist in sourcePath')
             .option('-r, --rsync-path', 'Path to rsync [/usr/bin/rsync]')
-            .parse(process.argv);
+            .parse(process.argv)
 
         const {
             sourceRelative: sourceEnv = 'PWD',


### PR DESCRIPTION
Since ibazel can't [watch for new files](https://github.com/bazelbuild/bazel-watcher/issues/135), we need to use our own file watcher.

Docker is somewhat problematic when it comes to node file watching, so we're implementing our own file watcher using sane in order to leverage watchman.